### PR TITLE
fix: modified error exports

### DIFF
--- a/source/errors/authenticationErrors.ts
+++ b/source/errors/authenticationErrors.ts
@@ -18,3 +18,11 @@ export function userNotFoundError() {
     message: 'user not found',
   };
 }
+
+const authErrors = {
+  invalidCredentialsError,
+  emailInUseError,
+  userNotFoundError,
+};
+
+export { authErrors };

--- a/source/errors/usersErrors.ts
+++ b/source/errors/usersErrors.ts
@@ -1,6 +1,12 @@
-export function userNotFoundError() {
+function userNotFoundError() {
   return {
     name: 'UserNotFound',
     message: 'user not found',
   };
 }
+
+const usersErrors = {
+  userNotFoundError,
+};
+
+export { usersErrors };

--- a/source/services/authenticationService.ts
+++ b/source/services/authenticationService.ts
@@ -1,4 +1,4 @@
-import { emailInUseError, invalidCredentialsError, userNotFoundError } from '@/errors';
+import { authErrors } from '@/errors';
 import { authRepository } from '@/repositories';
 import bcrypt from 'bcrypt';
 
@@ -11,13 +11,13 @@ type signUpBodyType = {
 
 async function handleSignUp({ name, email, password, confirmPassword }: signUpBodyType) {
   if (password !== confirmPassword) {
-    throw invalidCredentialsError();
+    throw authErrors.invalidCredentialsError();
   }
 
   const registeredEmail = await authRepository.findEmail(email);
 
   if (registeredEmail) {
-    throw emailInUseError();
+    throw authErrors.emailInUseError();
   }
 
   const hashedPassword = await bcrypt.hash(password, 10);
@@ -29,11 +29,11 @@ async function handleSignUp({ name, email, password, confirmPassword }: signUpBo
 async function handleLogin({ email, password }: signUpBodyType) {
   const userInfo = await authRepository.findEmail(email);
   if (!userInfo) {
-    throw userNotFoundError();
+    throw authErrors.userNotFoundError();
   }
   const validPassword = await bcrypt.compare(password, userInfo.password);
   if (!validPassword) {
-    throw invalidCredentialsError();
+    throw authErrors.invalidCredentialsError();
   }
   const session = await authRepository.newSession(userInfo.id);
   return session.token;

--- a/source/services/usersService.ts
+++ b/source/services/usersService.ts
@@ -1,4 +1,4 @@
-import { userNotFoundError } from '@/errors';
+import { usersErrors } from '@/errors';
 import { usersRepository } from '@/repositories';
 
 async function handleFetchUserInfo(userId: number) {
@@ -6,7 +6,7 @@ async function handleFetchUserInfo(userId: number) {
   const userInfo = await usersRepository.findUserInfo(userId);
 
   if (!userInfo) {
-    throw userNotFoundError();
+    throw usersErrors.userNotFoundError();
   }
 
   return { id: userInfo.id, name: userInfo.name, email: userInfo.email, image: userInfo.image };


### PR DESCRIPTION
- Modified error exports: errors related to the route should be imported through the correct error file

Correct usage: 
There's an error 'type' on 'route', the correct throw is: **throw routeErrors.typeError()**